### PR TITLE
Key names in connection strings are case insensitive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
-## v0.1.0 (2021-??-??)
+## v0.2.0 (2021-01-??)
+
+- Parsed query strings return lowercase keys [#3]
+
+## v0.1.0 (2021-01-21)
 
 Initial release

--- a/README.md
+++ b/README.md
@@ -25,10 +25,10 @@ Output to the console will be:
 
 ```json
 {
-  "User ID": "user",
-  "Password": "password",
-  "Initial Catalog": "AdventureWorks",
-  "Server": "MySqlServer"
+  "User id": "user",
+  "password": "password",
+  "initial catalog": "AdventureWorks",
+  "server": "MySqlServer"
 }
 ```
 
@@ -52,10 +52,10 @@ Output to console will be:
 
 ```json
 {
-  "User ID": "user",
-  "Password": "password",
-  "Initial Catalog": "AdventureWorks",
-  "Data Source": "MySqlServer"
+  "user id": "user",
+  "password": "password",
+  "initial catalog": "AdventureWorks",
+  "data source": "MySqlServer"
 }
 ```
 

--- a/src/parser/connection-string.ts
+++ b/src/parser/connection-string.ts
@@ -81,7 +81,7 @@ export default function connectionStringParser(connectionString: string, parserC
         }
         switch (collectionMode) {
             case CollectionMode.key:
-                currentKey = buffer;
+                currentKey = buffer.toLowerCase();
                 collectionMode = CollectionMode.value;
                 break;
             case CollectionMode.value:

--- a/src/parser/sql-connection-string.ts
+++ b/src/parser/sql-connection-string.ts
@@ -252,15 +252,18 @@ function validate(value: any, allowedValues?: any[], validator?: (val: any) => b
 
 export default function parseSqlConnectionString(connectionString: string, canonicalProps: boolean = false, strict: boolean = false, schema: SchemaDefinition = SCHEMA) {
     const flattenedSchema = Object.entries(schema).reduce((flattened: SchemaDefinition, [key, item]) => {
+        Object.assign(flattened, {
+            [key.toLowerCase()]: item,
+        });
         return item.aliases?.reduce((accum, alias: string) => {
             return Object.assign(accum, {
-                [alias]: {
+                [alias.toLowerCase()]: {
                     ...item,
-                    canonical: key,
+                    canonical: key.toLowerCase(),
                 },
             });
         }, flattened) || flattened;
-    }, { ...schema });
+    }, {});
     return Object.entries(parseConnectionString(connectionString)).reduce((config, [prop, value]) => {
         if (!Object.prototype.hasOwnProperty.call(flattenedSchema, prop)) {
             // @todo - allow assigning in un-recognised props

--- a/test/parser/fixture/connection-strings.json
+++ b/test/parser/fixture/connection-strings.json
@@ -3,79 +3,79 @@
     "name": "parses a single value",
     "connection_string": "Keyword=Value",
     "expected": {
-      "Keyword": "Value"
+      "keyword": "Value"
     }
   },
   {
     "name": "parses a single value with trailing semicolon",
     "connection_string": "Keyword=Value;",
     "expected": {
-      "Keyword": "Value"
+      "keyword": "Value"
     }
   },
   {
     "name": "parses keywords that contain `=`",
     "connection_string": "Key==word=Value",
     "expected": {
-      "Key=word": "Value"
+      "key=word": "Value"
     }
   },
   {
     "name": "parses values to contain `=`",
     "connection_string": "Keyword=Val=ue",
     "expected": {
-      "Keyword": "Val=ue"
+      "keyword": "Val=ue"
     }
   },
   {
     "name": "parses quoted values with double quotes",
     "connection_string": "Keyword=\"Value\"",
     "expected": {
-      "Keyword": "Value"
+      "keyword": "Value"
     }
   },
   {
     "name": "parses quoted values with single quotes",
     "connection_string": "Keyword='Value'",
     "expected": {
-      "Keyword": "Value"
+      "keyword": "Value"
     }
   },
   {
     "name": "parses values quoted with curly braces",
     "connection_string": "Keyword={Value}",
     "expected": {
-      "Keyword": "Value"
+      "keyword": "Value"
     }
   },
   {
     "name": "parses values with escaped closing curly brace",
     "connection_string": "Keyword={{Value}}}",
     "expected": {
-      "Keyword": "{Value}"
+      "keyword": "{Value}"
     }
   },
   {
     "name": "parses values with excessive whitespace",
     "connection_string": "  Keyword   =  Value  ;",
     "expected": {
-      "Keyword": "Value"
+      "keyword": "Value"
     }
   },
   {
     "name": "parses quoted values with excessive whitespace",
     "connection_string": " Keyword = {  Value } ;",
     "expected": {
-      "Keyword": "  Value "
+      "keyword": "  Value "
     }
   },
   {
     "name": "parses a documented connection string",
     "connection_string": "Persist Security Info=False;Integrated Security=true;Initial Catalog=Northwind;server=(local)",
     "expected": {
-      "Persist Security Info": "False",
-      "Integrated Security": "true",
-      "Initial Catalog": "Northwind",
+      "persist security info": "False",
+      "integrated security": "true",
+      "initial catalog": "Northwind",
       "server": "(local)"
     }
   },
@@ -83,76 +83,76 @@
     "name": "parses a standard connection string",
     "connection_string": "Server=192.168.0.1;Database=testdb;User Id=testuser;Password=testpwd",
     "expected": {
-      "Server": "192.168.0.1",
-      "Database": "testdb",
-      "User Id": "testuser",
-      "Password": "testpwd"
+      "server": "192.168.0.1",
+      "database": "testdb",
+      "user id": "testuser",
+      "password": "testpwd"
     }
   },
   {
     "name": "parses a connection string with protocol and port",
     "connection_string": "Server=tcp:192.168.0.1,1433;Database=testdb;User Id=testuser;Password=testpwd",
     "expected": {
-      "Server": "tcp:192.168.0.1,1433",
-      "Database": "testdb",
-      "User Id": "testuser",
-      "Password": "testpwd"
+      "server": "tcp:192.168.0.1,1433",
+      "database": "testdb",
+      "user id": "testuser",
+      "password": "testpwd"
     }
   },
   {
     "name": "parses a connection string with various quotes",
     "connection_string": "Server=192.168.0.1;Database=testdb;User Id={testuser};Password='t;estpwd'",
     "expected": {
-      "Server": "192.168.0.1",
-      "Database": "testdb",
-      "User Id": "testuser",
-      "Password": "t;estpwd"
+      "server": "192.168.0.1",
+      "database": "testdb",
+      "user id": "testuser",
+      "password": "t;estpwd"
     }
   },
   {
     "name": "parses a connection string with additional prameters",
     "connection_string": "Server=192.168.0.1;Database=testdb;User Id=testuser;Password=testpwd;MultiSubnetFailover=True",
     "expected": {
-      "Server": "192.168.0.1",
-      "Database": "testdb",
-      "User Id": "testuser",
-      "Password": "testpwd",
-      "MultiSubnetFailover": "True"
+      "server": "192.168.0.1",
+      "database": "testdb",
+      "user id": "testuser",
+      "password": "testpwd",
+      "multisubnetfailover": "True"
     }
   },
   {
     "name": "parses a connection string with connection timeout",
     "connection_string": "Server=192.168.0.1;Database=testdb;User Id=testuser;Password=testpwd;Connection Timeout=30",
     "expected": {
-      "Server": "192.168.0.1",
-      "Database": "testdb",
-      "User Id": "testuser",
-      "Password": "testpwd",
-      "Connection Timeout": "30"
+      "server": "192.168.0.1",
+      "database": "testdb",
+      "user id": "testuser",
+      "password": "testpwd",
+      "connection timeout": "30"
     }
   },
   {
     "name": "parses a connection string with ReadOnly application intent",
     "connection_string": "Server=192.168.0.1;Database=testdb;User Id=testuser;Password=testpwd;Connection Timeout=30;ApplicationIntent=ReadOnly",
     "expected": {
-      "Server": "192.168.0.1",
-      "Database": "testdb",
-      "User Id": "testuser",
-      "Password": "testpwd",
-      "Connection Timeout": "30",
-      "ApplicationIntent": "ReadOnly"
+      "server": "192.168.0.1",
+      "database": "testdb",
+      "user id": "testuser",
+      "password": "testpwd",
+      "connection timeout": "30",
+      "applicationintent": "ReadOnly"
     }
   },
   {
     "name": "parses a connection string with ReadWrite application intent",
     "connection_string": "Server=192.168.0.1;Database=testdb;User Id=testuser;Password=testpwd;Connection Timeout=30;ApplicationIntent=ReadWrite",
     "expected": {
-      "Server": "192.168.0.1",
-      "Database": "testdb",
-      "User Id": "testuser",
-      "Password": "testpwd",
-      "Connection Timeout": "30",
-      "ApplicationIntent": "ReadWrite"
+      "server": "192.168.0.1",
+      "database": "testdb",
+      "user id": "testuser",
+      "password": "testpwd",
+      "connection timeout": "30",
+      "applicationintent": "ReadWrite"
     }
   }
 ]

--- a/test/parser/fixture/sql-strings.json
+++ b/test/parser/fixture/sql-strings.json
@@ -3,11 +3,11 @@
     "name": "Parses a basic connection string",
     "connection_string": "Persist Security Info=False;User ID=user;Password=password;Initial Catalog=AdventureWorks;Server=MySqlServer",
     "expected": {
-      "Persist Security Info": false,
-      "User ID": "user",
-      "Password": "password",
-      "Initial Catalog": "AdventureWorks",
-      "Server":  "MySqlServer"
+      "persist security info": false,
+      "user id": "user",
+      "password": "password",
+      "initial catalog": "AdventureWorks",
+      "server":  "MySqlServer"
     },
     "canonical": false
   },
@@ -15,11 +15,11 @@
     "name": "Parses a basic connection string and uses canonical keys",
     "connection_string": "Persist Security Info=False;User ID=user;Password=password;Initial Catalog=AdventureWorks;Server=MySqlServer",
     "expected": {
-      "Persist Security Info": false,
-      "User ID": "user",
-      "Password": "password",
-      "Initial Catalog": "AdventureWorks",
-      "Data Source":  "MySqlServer"
+      "persist security info": false,
+      "user id": "user",
+      "password": "password",
+      "initial catalog": "AdventureWorks",
+      "data source":  "MySqlServer"
     },
     "canonical": true
   }


### PR DESCRIPTION
see https://docs.microsoft.com/en-us/dotnet/framework/data/adonet/connection-strings#connection-string-syntax

Connection string keys are not case sensitive. As such they will always be returned in lowercase,