### PR TITLE
ci: bump github actions

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -15,9 +15,9 @@ jobs:
         node-version: [10.x, 12.x, 14.x]
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v1
+      uses: actions/setup-node@v3
       with:
         node-version: ${{ matrix.node-version }}
     - run: npm ci


### PR DESCRIPTION
Bumps GitHub Actions to their latest major versions. Main change is they're now using Node 16 instead of 12, which is EOL at end of month.

- Changelog for `actions/checkout` can be [found here](https://github.com/actions/checkout/blob/main/CHANGELOG.md)
- Releases for `actions/setup-node` can be [found here](https://github.com/actions/setup-node/releases)