### PR TITLE
ci: reduce workflow permissions to minimum

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -5,6 +5,9 @@ name: Node.js CI
 
 on: [push, pull_request]
 
+permissions:
+  contents: read
+
 jobs:
   build:
 


### PR DESCRIPTION
Declares the minimum [permissions](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#permissions) for CI workflows to run at the workflow level, following principle of least privilege; see [related GitHub security post](https://securitylab.github.com/research/github-actions-building-blocks/)