### PR TITLE
chore: remove .prettierrc

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,5 +1,0 @@
-{
-  "printWidth": 120,
-  "trailingComma": "all",
-  "singleQuote": true
-}


### PR DESCRIPTION
Prettier was dropped in https://github.com/tediousjs/connection-string/pull/18, so this config file is no longer needed.