### PR TITLE
ci: remove git credentials after checkout

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -22,6 +22,8 @@ jobs:
 
     steps:
     - uses: actions/checkout@v3
+      with:
+        persist-credentials: false
     - name: Use Node.js ${{ matrix.node-version }}
       uses: actions/setup-node@v3
       with:


### PR DESCRIPTION
See option description at https://github.com/actions/checkout#usage.
Git is not used in any `run` commands after checking out the repo in any of the workflow's jobs, so best to remove the git credentials for security sake.