### PR TITLE
:bug: parse string values that start with numbers correctly

### DIFF
--- a/src/parser/sql-connection-string.ts
+++ b/src/parser/sql-connection-string.ts
@@ -227,7 +227,8 @@ function guessType(value: string): SchemaTypes {
     if (value.trim() === '') {
         return SchemaTypes.STRING;
     }
-    if (!Number.isNaN(parseInt(value, 10))) {
+    const asNum = parseInt(value, 10);
+    if (!Number.isNaN(asNum) && asNum.toString() === value) {
         return SchemaTypes.NUMBER;
     }
     if (['true', 'false', 'yes', 'no'].includes(value.toLowerCase())) {

--- a/test/parser/fixture/connection-strings.json
+++ b/test/parser/fixture/connection-strings.json
@@ -70,6 +70,13 @@
     }
   },
   {
+    "name": "parses a string value that starts with numbers",
+    "connection_string": "Keyword=012acb",
+    "expected": {
+      "keyword": "012acb"
+    }
+  },
+  {
     "name": "parses a documented connection string",
     "connection_string": "Persist Security Info=False;Integrated Security=true;Initial Catalog=Northwind;server=(local)",
     "expected": {

--- a/test/parser/fixture/sql-strings.json
+++ b/test/parser/fixture/sql-strings.json
@@ -38,5 +38,14 @@
     },
     "canonical": true,
     "allowUnknown": true
+  },
+  {
+    "name": "parses a string value that starts with numbers",
+    "connection_string": "client id=1e92dd5a-091f-4b2b-bc1b-8461ced6a177;client secret=55a4ef49-bef5-4669-818b-ff148c0c0db9;tenant id=5dc09092-ee09-4e5c-9515-ba937415e9ff;",
+    "expected": {
+      "client id": "1e92dd5a-091f-4b2b-bc1b-8461ced6a177",
+      "client secret": "55a4ef49-bef5-4669-818b-ff148c0c0db9",
+      "tenant id": "5dc09092-ee09-4e5c-9515-ba937415e9ff"
+    }
   }
 ]


### PR DESCRIPTION
As reported in the mssql library. Properties in connection strings that start with numbers are erroneously parsed as numbers instead of as strings.