### PR TITLE
:construction_worker: skip push workflow on dependabot branches

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -3,7 +3,11 @@
 
 name: Node.js CI
 
-on: [push, pull_request]
+on:
+  push:
+    branches-ignore:
+      - 'dependabot/**'
+  pull_request:
 
 permissions:
   contents: read


### PR DESCRIPTION
Dependabot branches are always opened as PRs so we don't need to perform the builds on the `push` event.