### PR TITLE
feat: add more authentication options

### DIFF
--- a/src/parser/sql-connection-string.ts
+++ b/src/parser/sql-connection-string.ts
@@ -48,7 +48,16 @@ export const SCHEMA: SchemaDefinition = {
     },
     'Authentication': {
         type: SchemaTypes.STRING,
-        allowedValues: ['Active Directory Integrated', 'Active Directory Password', 'Sql Password'],
+        allowedValues: [
+            'Active Directory Default',
+            'Active Directory Device Code Flow',
+            'Active Directory Integrated',
+            'Active Directory Interactive',
+            'Active Directory Managed Identity',
+            'Active Directory Password',
+            'Active Directory Service Principal',
+            'SQL Password',
+        ],
     },
     'Column Encryption Setting': {
         type: SchemaTypes.STRING,


### PR DESCRIPTION
Hey, would like to use this in a project but I need more authentication options:

SQL Server now has 8 options for `Authentication` as per https://learn.microsoft.com/en-us/sql/connect/ado-net/sql/azure-active-directory-authentication?view=sql-server-ver15#setting-microsoft-entra-authentication

