### PR TITLE
chore: upgrade typescript to v6

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -26,7 +26,7 @@
         "nyc": "^18.0.0",
         "semantic-release": "^25.0.3",
         "tsx": "^4.19.4",
-        "typescript": "^5.8.3",
+        "typescript": "^6.0.2",
         "typescript-eslint": "^8.33.1"
       }
     },
@@ -9691,9 +9691,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.9.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
-      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.2.tgz",
+      "integrity": "sha512-bGdAIrZ0wiGDo5l8c++HWtbaNCWTS4UTv7RaTH/ThVIgjkveJt83m74bBHMJkuCbslY8ixgLBVZJIOiQlQTjfQ==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "nyc": "^18.0.0",
     "semantic-release": "^25.0.3",
     "tsx": "^4.19.4",
-    "typescript": "^5.8.3",
+    "typescript": "^6.0.2",
     "typescript-eslint": "^8.33.1"
   }
 }

--- a/test/tsconfig.json
+++ b/test/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "../",
+  "extends": "../tsconfig.json",
   "compilerOptions": {
     "baseUrl": ".",
     "noEmit": true

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,7 +8,8 @@
     "outDir": "./lib",
     "declaration": true,
     "declarationMap": true,
-    "sourceMap": true
+    "sourceMap": true,
+    "types": ["node"]
   },
   "include": ["./src"]
 }


### PR DESCRIPTION
Upgrades TypeScript from v5 to v6.

### Changes

- **`package.json`**: Bump `typescript` from `^5.8.3` to `^6.0.2`
- **`tsconfig.json`**: Add explicit `"types": ["node"]` — TS6 no longer auto-includes `@types/*` packages
- **`test/tsconfig.json`**: Fix `extends` path from `"../"` to `"../tsconfig.json"` — TS6 no longer resolves bare directory extends to `tsconfig.json`

Build, lint, and all tests pass.