### PR TITLE
chore: upgrade tsconfig base from node20 to node22

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
         "@semantic-release/npm": "^13.1.5",
         "@semantic-release/release-notes-generator": "^14.1.0",
         "@stylistic/eslint-plugin": "^5.0.0",
-        "@tsconfig/node20": "^20.1.5",
+        "@tsconfig/node22": "^22.0.5",
         "@types/node": "^20.19.0",
         "c8": "^11.0.0",
         "eslint": "^10.0.2",
@@ -2307,10 +2307,10 @@
         "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
-    "node_modules/@tsconfig/node20": {
-      "version": "20.1.9",
-      "resolved": "https://registry.npmjs.org/@tsconfig/node20/-/node20-20.1.9.tgz",
-      "integrity": "sha512-IjlTv1RsvnPtUcjTqtVsZExKVq+KQx4g5pCP5tI7rAs6Xesl2qFwSz/tPDBC4JajkL/MlezBu3gPUwqRHl+RIg==",
+    "node_modules/@tsconfig/node22": {
+      "version": "22.0.5",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node22/-/node22-22.0.5.tgz",
+      "integrity": "sha512-hLf2ld+sYN/BtOJjHUWOk568dvjFQkHnLNa6zce25GIH+vxKfvTgm3qpaH6ToF5tu/NN0IH66s+Bb5wElHrLcw==",
       "dev": true,
       "license": "MIT"
     },

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "@semantic-release/npm": "^13.1.5",
     "@semantic-release/release-notes-generator": "^14.1.0",
     "@stylistic/eslint-plugin": "^5.0.0",
-    "@tsconfig/node20": "^20.1.5",
+    "@tsconfig/node22": "^22.0.5",
     "@types/node": "^20.19.0",
     "c8": "^11.0.0",
     "eslint": "^10.0.2",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json.schemastore.org/tsconfig",
-  "extends": "@tsconfig/node20",
+  "extends": "@tsconfig/node22",
   "compilerOptions": {
     "module": "nodenext",
     "moduleResolution": "nodenext",


### PR DESCRIPTION
The project targets Node 22 (per `.nvmrc`), so the tsconfig base should match.

Swaps `@tsconfig/node20` for `@tsconfig/node22`, which upgrades `lib` from `es2023` to `es2024` with ESNext additions.