### PR TITLE
feat: add exports field to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,12 @@
   "homepage": "https://github.com/tediousjs/connection-string#readme",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./lib/index.d.ts",
+      "default": "./lib/index.js"
+    }
+  },
   "scripts": {
     "prepare": "tsc",
     "build": "tsc",


### PR DESCRIPTION
Adds a modern `exports` map for explicit entry point resolution. This gives consumers better module resolution guarantees, especially with ESM tooling.

Retains `main` and `types` for backwards compatibility with older tooling.