### PR TITLE
test: add parser error path tests

### DIFF
--- a/test/parser/connection-string.test.ts
+++ b/test/parser/connection-string.test.ts
@@ -15,4 +15,30 @@ describe('parser', () => {
             });
         });
     });
+
+    describe('error handling', () => {
+        it('throws on malformed connection string with trailing characters after quoted value', () => {
+            assert.throws(() => parse('key="value"garbage'), {
+                message: 'Malformed connection string',
+            });
+        });
+
+        it('throws on unterminated double-quoted value', () => {
+            assert.throws(() => parse('key="unterminated'), {
+                message: 'Connection string terminated unexpectedly',
+            });
+        });
+
+        it('throws on unterminated single-quoted value', () => {
+            assert.throws(() => parse('key=\'unterminated'), {
+                message: 'Connection string terminated unexpectedly',
+            });
+        });
+
+        it('throws on unterminated brace-quoted value', () => {
+            assert.throws(() => parse('key={unterminated'), {
+                message: 'Connection string terminated unexpectedly',
+            });
+        });
+    });
 });


### PR DESCRIPTION
Adds tests for the two previously untested `throw` paths in `connection-string-parser.ts`:

- **Malformed connection string** — trailing non-whitespace characters after a quoted value
- **Unterminated quoted values** — double quotes, single quotes, and brace quotes that never close