### PR TITLE
build: pin npm via packageManager to keep lockfile deterministic

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@tediousjs/connection-string",
   "version": "1.1.0",
+  "packageManager": "npm@10.9.8",
   "description": "SQL ConnectionString parser",
   "repository": {
     "type": "git",


### PR DESCRIPTION
## What

Pin the package manager to `npm@10.9.8` via the `packageManager` field in `package.json`. No dependency versions change; the committed `package-lock.json` is unaffected.

## Why

The open Dependabot PRs (#258, #259, #260) all fail CI at `npm ci` with:

```
npm error code EUSAGE
npm error Missing: conventional-commits-filter@6.0.1 from lock file
```

Root cause is an **npm 10 vs 11 lockfile skew**, not the dependency updates themselves:

- **npm 11** (what Dependabot currently uses to regenerate the lockfile) dedupes and **omits** the nested `@commitlint/read/node_modules/conventional-commits-filter@6.0.1` entry.
- **npm 10** (what CI runs — Node 22 via `.nvmrc` bundles npm 10) **keeps** that nested entry, so its `npm ci` rejects an npm‑11‑generated lockfile as out of sync.

Verified empirically:

| Lockfile generated by | `npm ci` run by | Result |
|---|---|---|
| npm 10 (current `master`) | npm 10 | ✅ in sync |
| npm 10 (current `master`) | npm 11 | ✅ accepted |
| npm 11 | npm 10 | ❌ `Missing: conventional-commits-filter@6.0.1` |

Pinning `packageManager` to `npm@10.9.8` makes lockfile generation deterministic across contributors **and Dependabot**, matching the npm that CI actually runs.

## Caveat

This relies on Dependabot honouring the `packageManager` field when it regenerates lockfiles. If it does, rebasing #258/#259/#260 on top of this will produce npm‑10‑shaped lockfiles and CI will pass. If Dependabot does **not** honour it, those three PRs may still need their lockfiles regenerated with npm 10 directly.

## Testing

- `master`'s lockfile is already npm‑10‑shaped, so this change is pin‑only — `npm install --package-lock-only` under npm 10.9.8 leaves the lockfile byte‑for‑byte unchanged.
- `npm ci` under npm 10.9.8 passes on this branch.
